### PR TITLE
feat (api): Reworks Recent Posts with Types and Data Mapping with Response Caching

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@graphql-yoga/plugin-response-cache": "^3.3.0",
     "@redwoodjs/api": "6.6.2",
     "@redwoodjs/graphql-server": "6.6.2",
     "graphql-request": "^6.1.0"

--- a/api/src/functions/graphql.ts
+++ b/api/src/functions/graphql.ts
@@ -19,6 +19,7 @@ export const handler = createGraphQLHandler({
       session: () => null,
       // by default cache all operations for 2 seconds
       ttl: 2_000,
+      // can just cache recent posts for a different amount of time etc
     }),
   ],
   onException: () => {

--- a/api/src/functions/graphql.ts
+++ b/api/src/functions/graphql.ts
@@ -1,3 +1,5 @@
+import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
+
 import { createGraphQLHandler } from '@redwoodjs/graphql-server'
 
 import directives from 'src/directives/**/*.{js,ts}'
@@ -12,6 +14,13 @@ export const handler = createGraphQLHandler({
   directives,
   sdls,
   services,
+  extraPlugins: [
+    useResponseCache({
+      session: () => null,
+      // by default cache all operations for 2 seconds
+      ttl: 2_000,
+    }),
+  ],
   onException: () => {
     // Disconnect from your database with an unhandled exception.
     db.$disconnect()

--- a/api/src/functions/graphql.ts
+++ b/api/src/functions/graphql.ts
@@ -17,9 +17,9 @@ export const handler = createGraphQLHandler({
   extraPlugins: [
     useResponseCache({
       session: () => null,
-      // by default cache all operations for 2 seconds
-      ttl: 2_000,
-      // can just cache recent posts for a different amount of time etc
+      ttlPerSchemaCoordinate: {
+        'Query.recentPosts': 10 * 1_000, // 10 seconds
+      },
     }),
   ],
   onException: () => {

--- a/api/src/graphql/hashnode.sdl.ts
+++ b/api/src/graphql/hashnode.sdl.ts
@@ -2,7 +2,7 @@ export const schema = gql`
   type Publication {
     isTeam: Boolean
     title: String!
-    posts: [Post!]!
+    posts: [Post!]
   }
 
   type Post {
@@ -10,7 +10,7 @@ export const schema = gql`
     title: String!
     brief: String!
     url: String!
-    # author: Author!
+    author: Author!
   }
 
   type Author {

--- a/api/src/graphql/hashnode.sdl.ts
+++ b/api/src/graphql/hashnode.sdl.ts
@@ -20,6 +20,6 @@ export const schema = gql`
   }
 
   type Query {
-    recentPosts: Publication! @skipAuth
+    recentPosts(first: Int): Publication! @skipAuth
   }
 `

--- a/api/src/services/hashnode.ts
+++ b/api/src/services/hashnode.ts
@@ -16,7 +16,12 @@ type PublicationResponse = {
 type RecentPostsResponse = {
   publication: PublicationResponse
 }
-
+/**
+ * Fetches a Publication with latest posts from Hashnode.
+ *
+ * Note: This resolver is cached for a specified amount of time
+ * defined in the GraphQL Handler in ttlPerSchemaCoordinate.
+ **/
 export const recentPosts = async ({
   first = 3,
 }: QueryrecentPostsArgs): Promise<Publication> => {

--- a/api/src/services/hashnode.ts
+++ b/api/src/services/hashnode.ts
@@ -1,5 +1,5 @@
 import { request } from 'graphql-request'
-import type { Post, Publication } from 'types/graphql'
+import type { Post, Publication, QueryrecentPostsArgs } from 'types/graphql'
 
 import { logger } from 'src/lib/logger'
 
@@ -17,13 +17,15 @@ type RecentPostsResponse = {
   publication: PublicationResponse
 }
 
-export const recentPosts = async () => {
+export const recentPosts = async ({
+  first = 3,
+}: QueryrecentPostsArgs): Promise<Publication> => {
   const RECENT_POSTS = `
     {
       publication(host: "selfteach.me") {
         isTeam
         title
-        posts(first: 10) {
+        posts(first: ${first}) {
           edges {
             node {
               id

--- a/api/src/services/hashnode.ts
+++ b/api/src/services/hashnode.ts
@@ -1,8 +1,24 @@
 import { request } from 'graphql-request'
-import gql from 'graphql-tag'
+import type { Post, Publication } from 'types/graphql'
+
+import { logger } from 'src/lib/logger'
+
+type PublicationResponse = {
+  isTeam: boolean
+  title: string
+  posts: {
+    edges: Array<{
+      node: Post
+    }>
+  }
+}
+
+type RecentPostsResponse = {
+  publication: PublicationResponse
+}
 
 export const recentPosts = async () => {
-  const query = gql`
+  const RECENT_POSTS = `
     {
       publication(host: "selfteach.me") {
         isTeam
@@ -25,11 +41,26 @@ export const recentPosts = async () => {
       }
     }
   `
-  const data = await request('https://gql.hashnode.com', query)
-  console.log({ data })
-  return {
-    isTeam: data.publication.isTeam,
-    title: data.publication.title,
-    posts: data.publication.posts.edges.map((edge: any) => edge.node),
+
+  try {
+    const { publication } = await request<RecentPostsResponse>(
+      'https://gql.hashnode.com',
+      RECENT_POSTS
+    )
+
+    if (!publication) {
+      throw new Error('Failed to fetch recent posts')
+    }
+
+    logger.debug(publication, 'Recent posts response from hashnode')
+
+    return {
+      isTeam: publication.isTeam,
+      title: publication.title,
+      posts: publication.posts?.edges?.map((edge) => edge.node as Post),
+    } as Publication
+  } catch (error) {
+    logger.error(error, 'Failed to fetch recent posts')
+    throw new Error('Failed to fetch recent posts')
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,6 +2040,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@envelop/response-cache@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@envelop/response-cache@npm:6.1.2"
+  dependencies:
+    "@graphql-tools/utils": "npm:^10.0.3"
+    "@whatwg-node/fetch": "npm:^0.9.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    lru-cache: "npm:^10.0.0"
+    tslib: "npm:^2.5.0"
+  peerDependencies:
+    "@envelop/core": ^5.0.0
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 60c3304e819997ff584314c2fae82d88e603f031e3b2965f4ac5e94e5350462da9785a381e5e1c9d3379923b24c9d2f36b57f9e10bd80e0c97546a540c47c726
+  languageName: node
+  linkType: hard
+
 "@envelop/types@npm:4.0.1":
   version: 4.0.1
   resolution: "@envelop/types@npm:4.0.1"
@@ -3482,6 +3498,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-tools/utils@npm:^10.0.3":
+  version: 10.0.13
+  resolution: "@graphql-tools/utils@npm:10.0.13"
+  dependencies:
+    "@graphql-typed-document-node/core": "npm:^3.1.1"
+    cross-inspect: "npm:1.0.0"
+    dset: "npm:^3.1.2"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 6505c494716bb7aa36eba3d731f5a3e28c0bbd2efc818f1fdc7367a408ced8878bfff40f4dafbcef70d912219df81484e32e28130366e8355c126fcbc8ac9dd5
+  languageName: node
+  linkType: hard
+
 "@graphql-tools/utils@npm:^8.8.0":
   version: 8.13.1
   resolution: "@graphql-tools/utils@npm:8.13.1"
@@ -3535,6 +3565,18 @@ __metadata:
   dependencies:
     tslib: "npm:^2.5.2"
   checksum: b43a7c86faad2447a696b2c4f46e9219cc1ae95484857c8f54e5ad4ba7d984a3f37149c45320659ffc89da2aefdb44ad2a68a5b57acb88d3aad86caad2a8bcfe
+  languageName: node
+  linkType: hard
+
+"@graphql-yoga/plugin-response-cache@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@graphql-yoga/plugin-response-cache@npm:3.3.0"
+  dependencies:
+    "@envelop/response-cache": "npm:^6.1.2"
+  peerDependencies:
+    graphql: ^15.2.0 || ^16.0.0
+    graphql-yoga: ^5.1.1
+  checksum: a4b2998d1adf545816f8fb88399a27ea091295201273603dc5bc5f32b64d855424883396fbe176b8c73be923f17793df937da3e4ca74b66f4bc4bce64ea5c0f1
   languageName: node
   linkType: hard
 
@@ -8634,6 +8676,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@whatwg-node/fetch@npm:^0.9.0":
+  version: 0.9.16
+  resolution: "@whatwg-node/fetch@npm:0.9.16"
+  dependencies:
+    "@whatwg-node/node-fetch": "npm:^0.5.5"
+    urlpattern-polyfill: "npm:^10.0.0"
+  checksum: 757fd8560ee1a9ae404dafc43115eb37c72022c9bd3a30bc1c0028178cdece84d7378244fff4bad28ebbb3f2cc0b0b2ff738612824ed32bbd9dac49f5d0d5b42
+  languageName: node
+  linkType: hard
+
 "@whatwg-node/fetch@npm:^0.9.10, @whatwg-node/fetch@npm:^0.9.7":
   version: 0.9.15
   resolution: "@whatwg-node/fetch@npm:0.9.15"
@@ -8667,6 +8719,19 @@ __metadata:
     fast-querystring: "npm:^1.1.1"
     tslib: "npm:^2.3.1"
   checksum: 8a2f2c5a4138b734a45db93899fe5304e7b7821d4a8708bcd10ad860988381acb76907d2b21aa867f784760393c9da68105e8052b7e371d9acf208c9668822b2
+  languageName: node
+  linkType: hard
+
+"@whatwg-node/node-fetch@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@whatwg-node/node-fetch@npm:0.5.5"
+  dependencies:
+    "@kamilkisiela/fast-url-parser": "npm:^1.1.4"
+    "@whatwg-node/events": "npm:^0.1.0"
+    busboy: "npm:^1.6.0"
+    fast-querystring: "npm:^1.1.1"
+    tslib: "npm:^2.3.1"
+  checksum: e40964eb6d74847ff362136d4199a3f0dc4cb6596961b9a12fd5e3635410a28577609fb4879ef02909f7fad42c977d4b9a1f6715c48dc2272558c96d62ac6132
   languageName: node
   linkType: hard
 
@@ -9168,6 +9233,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api@workspace:api"
   dependencies:
+    "@graphql-yoga/plugin-response-cache": "npm:^3.3.0"
     "@redwoodjs/api": "npm:6.6.2"
     "@redwoodjs/graphql-server": "npm:6.6.2"
     graphql-request: "npm:^6.1.0"
@@ -25388,6 +25454,13 @@ __metadata:
     punycode: "npm:^1.4.1"
     qs: "npm:^6.11.2"
   checksum: 7546b878ee7927cfc62ca21dbe2dc395cf70e889c3488b2815bf2c63355cb3c7db555128176a01b0af6cccf265667b6fd0b4806de00cb71c143c53986c08c602
+  languageName: node
+  linkType: hard
+
+"urlpattern-polyfill@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "urlpattern-polyfill@npm:10.0.0"
+  checksum: 43593f2a89bd54f2d5b5105ef4896ac5c5db66aef723759fbd15cd5eb1ea6cdae9d112e257eda9bbc3fb0cd90be6ac6e9689abe4ca69caa33114f42a27363531
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The Recent Posts service now can fetch a publication with posts from the Hashnode public GraphQL API.

The data is typed and parsed into populated Posts and Authors.

Also, GraphQL Response Caching is configured as to not repeatedly query the Hashnode API for better response and less requests.

Note that the response cache is currently in memory but can be setup to use Redis or other cache when deployed.

### Usage:


```graphql
query GetRecentPosts {
  recentPosts(first: 5)  {
    isTeam
    title
    posts {
      id
      title
      author {
        id
        name
      }
    }
  }
}
```

### Results:

```json
{
  "data": {
    "recentPosts": {
      "isTeam": false,
      "title": "SelfTeach.me",
      "posts": [
        {
          "id": "655b0dd456f7b88939bf0fc8",
          "title": "Ultimate Beginner’s Guide to Using the Terminal",
          "author": {
            "id": "5f8114d07762251b305d8bce",
            "name": "Amy Dutton"
          }
        },
        {
          "id": "641de6c534617914fa16beac",
          "title": "Planning for Success: My Approach to Designing Applications",
          "author": {
            "id": "5f8114d07762251b305d8bce",
            "name": "Amy Dutton"
          }
        },
        {
          "id": "64011d5dc4e2b7e94bbf7e51",
          "title": "PlopJS: The Tool Every Developer Needs for a Faster Workflow",
          "author": {
            "id": "5f8114d07762251b305d8bce",
            "name": "Amy Dutton"
          }
        },
        {
          "id": "63f7c576e175db7df278ec2d",
          "title": "65 Must Have VS Code Extensions That Will Boost Your Developer Experience",
          "author": {
            "id": "5f8114d07762251b305d8bce",
            "name": "Amy Dutton"
          }
        }
      ]
    }
  },
  "extensions": {
    "responseCache": {
      "hit": false,
      "didCache": true,
      "ttl": 10000
    }
  }
}```
